### PR TITLE
19 updating items

### DIFF
--- a/sick-fits/backend/src/resolvers/Mutation.js
+++ b/sick-fits/backend/src/resolvers/Mutation.js
@@ -9,6 +9,19 @@ const Mutations = {
 		}, info);
 
 		return item;
+	},
+	updateItem(parent, args, ctx, info) {
+		// take a copy of the updates
+		const updates = { ...args };
+		// remove gthe ID from the updates
+		delete updates.id;
+		// run the update method
+		return ctx.db.mutation.updateItem({
+			data: updates,
+			where: {
+				id: args.id
+			},
+		}, info);
 	}
 };
 

--- a/sick-fits/backend/src/resolvers/Query.js
+++ b/sick-fits/backend/src/resolvers/Query.js
@@ -1,9 +1,13 @@
-const Query = {
-	async items(parent, args, ctx, info) {
-		const items = await ctx.db.query.items();
+const { forwardTo } = require('prisma-binding');
 
-		return items;
-	}
+const Query = {
+	items: forwardTo('db'),
+	item: forwardTo('db'),
+	// async items(parent, args, ctx, info) {
+	// 	const items = await ctx.db.query.items();
+
+	// 	return items;
+	// }
 };
 
 module.exports = Query;

--- a/sick-fits/backend/src/schema.graphql
+++ b/sick-fits/backend/src/schema.graphql
@@ -1,9 +1,17 @@
 # import * from 'generated/prisma.graphql'
 
 type Mutation {
-	createItem(title: String, description: String, price: Int, image: String, largeImage: String): Item!
+	createItem(
+		title: String
+		description: String
+		price: Int
+		image: String
+		largeImage: String
+	): Item!
+	updateItem(id: ID!, title: String, description: String, price: Int): Item!
 }
 
 type Query {
 	items: [Item]!
+	item(where: ItemWhereUniqueInput!): Item
 }

--- a/sick-fits/frontend/components/UpdateItem.js
+++ b/sick-fits/frontend/components/UpdateItem.js
@@ -1,0 +1,134 @@
+import React, { Component } from 'react';
+import { Mutation, Query } from 'react-apollo';
+import gql from 'graphql-tag';
+import Router from 'next/router';
+
+import Form from './styles/Form';
+import Error from './ErrorMessage';
+import formatMoney from '../lib/formatMoney';
+
+const SINGLE_ITEM_QUERY = gql`
+	query SINGLE_ITEM_QUERY($id: ID!) {
+		item(where: { id: $id }) {
+			id
+			title
+			description
+			price
+		}
+	}
+`;
+
+const UPDATE_ITEM_MUTATION = gql`
+  mutation UPDATE_ITEM_MUTATION(
+  	$id: ID!
+    $title: String
+    $description: String
+    $price: Int
+  ) {
+    updateItem(
+			id: $id
+      title: $title
+      description: $description
+      price: $price
+    ) {
+      id
+      title
+      description
+      price
+    }
+  }
+`;
+
+class UpdateItem extends Component {
+  state = { };
+
+  handleChange = e => {
+    const { name, type, value } = e.target;
+    const val = type === 'number' ? parseFloat(value) : value;
+
+    this.setState({ [name]: val });
+  };
+
+  updateItem = async (e, updateItemMutation) => {
+  	e.preventDefault();
+  	console.log('Updating Item...');
+  	console.log(this.state);
+
+  	const res = await updateItemMutation({
+  		variables: {
+  			id: this.props.id,
+  			...this.state,
+  		}
+  	});
+
+  	console.log('Updated!');
+  }
+
+  render() {
+    return (
+    	<Query query={SINGLE_ITEM_QUERY} variables={{
+    		id: this.props.id
+    	}}>
+    		{({ data, loading }) => {
+    			if (loading) return <p>Loading...</p>;
+    			if (!data.item) return <p>No Item Found for ID {this.props.id}</p>
+    			return (
+			      <Mutation mutation={UPDATE_ITEM_MUTATION} variables={this.state}>
+			        {(updateItem, { loading, error }) => (
+			          <Form
+			            onSubmit={e => this.updateItem(e, updateItem)}
+			          >
+			            <Error error={error} />
+			            <fieldset disabled={loading} aria-busy={loading}>
+			              <label htmlFor="title">
+			                Title
+			                <input
+			                  type="text"
+			                  id="title"
+			                  name="title"
+			                  placeholder="Title"
+			                  required
+			                  defaultValue={data.item.title}
+			                  onChange={this.handleChange}
+			                />
+			              </label>
+
+			              <label htmlFor="price">
+			                Price
+			                <input
+			                  type="number"
+			                  id="price"
+			                  name="price"
+			                  placeholder="Price"
+			                  required
+			                  defaultValue={data.item.price}
+			                  onChange={this.handleChange}
+			                />
+			              </label>
+
+			              <label htmlFor="description">
+			                Description
+			                <textarea
+			                  id="description"
+			                  name="description"
+			                  placeholder="Enter A Description"
+			                  required
+			                  defaultValue={data.item.description}
+			                  onChange={this.handleChange}
+			                />
+			              </label>
+
+			              <button type="submit">Sav{loading ? 'ing' : 'e'} Changes</button>
+			            </fieldset>
+			          </Form>
+			        )}
+			      </Mutation>
+    			)
+    		}}
+	  	</Query>
+    );
+  }
+}
+
+export default UpdateItem;
+export { UPDATE_ITEM_MUTATION, SINGLE_ITEM_QUERY };

--- a/sick-fits/frontend/pages/update.js
+++ b/sick-fits/frontend/pages/update.js
@@ -1,0 +1,9 @@
+import UpdateItem from '../components/UpdateItem';
+
+const Sell = ({ query }) => (
+  <div>
+    <UpdateItem id={query.id}/>
+  </div>
+);
+
+export default Sell;


### PR DESCRIPTION
Backend:
-schema.graphql houses the updateItem and item mutation and query types
-resolvers folder contains the way to retrieve the fields from updateItem and item, usually just use forwardTo from Prisma bindings to forward requests to db

Frontend:
-create a component to house the updateItem mutations and single item query use respective Query and Mutation components to pass the required mutations or queries
