### PR TITLE
Create single item page

### DIFF
--- a/sick-fits/frontend/components/SingleItem.js
+++ b/sick-fits/frontend/components/SingleItem.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import gql from 'graphql-tag';
+import Head from 'next/head';
+import { Query } from 'react-apollo';
+import styled from 'styled-components';
+
+import { SINGLE_ITEM_QUERY } from './UpdateItem';
+import Error from './ErrorMessage';
+
+const SingleItemStyles = styled.div`
+	max-width: 1200px;
+	margin: 2rem auto;
+	box-shadow: ${props => props.theme.bs};
+	display: grid;
+	grid-auto-columns: 1fr;
+	grid-auto-flow: column;
+	min-height: 800px;
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+
+	.details {
+		margin: 3rem;
+		font-size: 2rem;
+	}
+`
+
+class SingleItem extends Component {
+	render() {
+		return (
+			<Query
+				query={SINGLE_ITEM_QUERY}
+				variables={{
+					id: this.props.id
+				}}
+			>
+				{({error, loading, data}) => {
+					if (error) return <Error error={error} />;
+					if (loading) return <p>Loading...</p>;
+					if (!data.item) return <p>No Item Found</p>;
+					const item = data.item;
+					return <SingleItemStyles>
+						<Head>
+							<title>Sick Fits!  | {item.title}</title>
+						</Head>
+						<img src={item.largeImage} alt={item.title}/>
+						<div className='details'>
+							<h2>Viewing {item.title}</h2>
+							<p>{item.description}</p>
+						</div>
+					</SingleItemStyles>;
+				}}
+			</Query>
+		)
+	}
+}
+
+export default SingleItem;

--- a/sick-fits/frontend/components/UpdateItem.js
+++ b/sick-fits/frontend/components/UpdateItem.js
@@ -14,6 +14,7 @@ const SINGLE_ITEM_QUERY = gql`
 			title
 			description
 			price
+			largeImage
 		}
 	}
 `;

--- a/sick-fits/frontend/pages/item.js
+++ b/sick-fits/frontend/pages/item.js
@@ -1,0 +1,9 @@
+import SingleItem from '../components/SingleItem';
+
+const Item = props => (
+  <div>
+    <SingleItem id={props.query.id}/>
+  </div>
+);
+
+export default Item;


### PR DESCRIPTION
backend:
- schema and resolvers were already in place

frontend:
- Create an item.js page for the single item that will house the SingleItem component
- Create SingleItem component that houses the Query for the single item
- Used styled components to style the whole page including changing the title on the <head>