### PR TITLE
Prime backend to allow resetting password.

### DIFF
--- a/sick-fits/backend/src/schema.graphql
+++ b/sick-fits/backend/src/schema.graphql
@@ -16,6 +16,12 @@ type Mutation {
 	signup(email: String!, password: String!, name: String!): User!
 	signin(email: String!, password: String!): User!
 	signout: SuccessMessage
+	requestReset(email: String!): SuccessMessage
+	resetPassword(
+		resetToken: String!
+		password: String!
+		confirmPassword: String!
+	): User!
 }
 
 type Query {
@@ -28,4 +34,11 @@ type Query {
 	item(where: ItemWhereUniqueInput!): Item
 	itemsConnection(where: ItemWhereInput): ItemConnection!
 	me: User
+}
+
+type User {
+	id: ID!
+	name: String!
+	email: String!
+	permissions: [Permission!]!
 }


### PR DESCRIPTION
Backend:
- Redefine the User type in the schema to disallow field leaks into the frontend
- Add mutation function to set a resetToken that expires in an hour
-Add mutation function that takes in the resetToken and if it's valid and not expired, it sets a new password